### PR TITLE
Configured for denver-clojurebridge org

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,9 +5,9 @@ description: > # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-url: "http://clojurebridge.github.io/"
+url: "http://denver-clojurebridge.github.io/"
 twitter_username: ClojureBridge
-github_username:  ClojureBridge
+github_username:  denver-clojurebridge
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
This should make the http://denver-clojurebridge.github.io/curriculum link work properly
